### PR TITLE
[Docs] Add `company`, `job`, and `url` to vCard example

### DIFF
--- a/docs/v-card.md
+++ b/docs/v-card.md
@@ -13,6 +13,9 @@ Route::get('qr-code/examples/v-card', function ()
     $lastName = 'Doe';
     $title = 'Mr.';
     $email = 'john.doe@example.com';
+    $company = "Acme Inc.";
+    $job = "Developer";
+    $url = "https://example.com";
     
     // Addresses
     $homeAddress = [
@@ -55,7 +58,7 @@ Route::get('qr-code/examples/v-card', function ()
     
     $phones = [$workPhone, $homePhone, $cellPhone];
     
-    return QRCode::vCard($firstName, $lastName, $title, $email, $addresses, $phones)
+    return QRCode::vCard($firstName, $lastName, $title, $email, $company, $job, $url, $addresses, $phones)
                 ->setErrorCorrectionLevel('H')
                 ->setSize(4)
                 ->setMargin(2)


### PR DESCRIPTION
The current [vCard example](https://github.com/giauphan/laravel-qr-code/blob/master/docs/v-card.md) results in the following error:

```
LaravelQRCode\QRCodeFactory::vCard(): Argument #5 ($company) must be of type ?string, array given
```

The `vCard` method:
https://github.com/giauphan/laravel-qr-code/blob/094ebc36389c41bc0e253a5f758f5c60ffd34c55/src/QRCodeFactory.php#L170

This PR adds the missing parameters `company`, `job`, and `url` to the example.